### PR TITLE
Resolves #11 duplicate ReSharper NUnit assemblies

### DIFF
--- a/Xania.AspNet.Simulator/MvcApplication.cs
+++ b/Xania.AspNet.Simulator/MvcApplication.cs
@@ -142,7 +142,10 @@ namespace Xania.AspNet.Simulator
 
                 foreach (var assembly in runtimeAssemblies)
                 {
-                    result.Add(assembly.Name, assembly.Location);
+                    if (!result.ContainsKey(assembly.Name))
+                    {
+                        result.Add(assembly.Name, assembly.Location);
+                    }
                 }
 
                 return result.Values;


### PR DESCRIPTION
The JetBrains.ReSharper.UnitTestRunner.nUnit30.dll assembly was coming from the standard location and also from a temp directory, causing MvcApplication.Assemblies to throw and Simulator unable to run.
